### PR TITLE
Add AMI in the dummy.tf file

### DIFF
--- a/dummy.tf
+++ b/dummy.tf
@@ -18,3 +18,7 @@ variable "image_id" {
 variable "instance_type" {
   type = string
 }
+variable "ami" {
+  type = string
+  default = "ami2320320332"
+}


### PR DESCRIPTION
This is a pull request to plan Terraform changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option for specifying AMI (Amazon Machine Image) in the infrastructure setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->